### PR TITLE
Update metaBEAT_global_misc_functions.py

### DIFF
--- a/scripts/DEVEL/metaBEAT_global_misc_functions.py
+++ b/scripts/DEVEL/metaBEAT_global_misc_functions.py
@@ -45,7 +45,7 @@ def find_target_OTUs_by_taxonomy(BIOM, target, level='all'):
     from biom.table import Table
     
     return_OTUs = {}
-    levels = ['kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species']
+    levels = ['superkingdom', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species']
     levels_valid = ['all','unassigned']
     levels_valid.extend(levels)
     search_levels = []


### PR DESCRIPTION
New taxonomy in BIOM files now include superkingdom rank as well, without it the function doesn't seem to find the right OTUs from BIOM files.